### PR TITLE
upgraded js-helper version to the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Change log.
 
+## Version 2.3.4
+
+* Upgraded the `js-helper` version to the latest
+
 ## Version 2.3.3
 
 * Sender unrefs the socket by default. Adds the `unref` option.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devo/nodejs-sdk",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Devo SDK for Node.js",
   "author": "Devo Dev Team",
   "eslintConfig": {
@@ -35,7 +35,7 @@
     "basic-request": "1.2.2",
     "command-line-args": "4.0.2",
     "command-line-usage": "4.0.0",
-    "@devo/js-helper": "^1.3.0",
+    "@devo/js-helper": "^1.6.2",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
upgraded js-helper version to the latest. This PR depends on [this other PR](https://github.com/DevoInc/js-helper/pull/7).